### PR TITLE
#985 Don't disable existing loggers by default

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -762,14 +762,16 @@ class Configuration(object):
         :param level:       Logging level of root logger.
                             If None, use :attr:`logging_level` value.
         :param configfile:  Configuration filename for fileConfig() setup.
-        :param kwargs:      Passed to :func:`logging.basicConfig()`
+        :param kwargs:      Passed to :func:`logging.basicConfig()` or
+                            :func:`logging.config.fileConfig()`
         """
         if level is None:
             level = self.logging_level      # pylint: disable=no-member
 
         if configfile:
             from logging.config import fileConfig
-            fileConfig(configfile)
+            disable_existing_loggers = kwargs.pop("disable_existing_loggers", False)
+            fileConfig(configfile, disable_existing_loggers=disable_existing_loggers, **kwargs)
         else:
             # pylint: disable=no-member
             format_ = kwargs.pop("format", self.logging_format)


### PR DESCRIPTION
Rationale:
In behave, loggers are usually initialized before "before_all()" and "setup_logging()" are invoked. When using a file config, the default behavior of the logging module is to disable existing loggers (see warning in https://docs.python.org/3/howto/logging.html#configuring-logging). Changing the default behavior to not disabling the existing loggers matches behaves logger users better. By passing the **kwargs into "fileConfig()", we still allow all desired behaviors.