### PR TITLE
fix badly typed runner args

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -570,9 +570,10 @@ class ModelRunner(object):
 
     def __init__(self, config, features=None, step_registry=None):
 
-        self.runner_args = dict()
         if config and config.unknown_args:
             self.runner_args = self.get_parser().parse_args(config.unknown_args)
+        else:
+            self.runner_args = argparse.Namespace()
 
         self.config = config
         self.features = features or []

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1112,7 +1112,7 @@ class TestRunnerArgs():
     def test_no_runner_args(self):
         config = create_mock_config()
         r = runner.Runner(config)
-        assert len(r.runner_args) == 0
+        assert len(r.runner_args.__dict__) == 0
 
     def test_unsupported_runner_args(self, capsys):
         """The default runner class doesn't provide a specific parser and hence doesn't accept
@@ -1135,6 +1135,6 @@ class TestRunnerArgs():
         config = create_mock_config()
         config.unknown_args = ['--supported-arg', 'value']
         r = TestRunnerArgs.SpecificRunner(config)
-        print(r.runner_args)
         assert 'supported_arg' in r.runner_args
         assert r.runner_args.supported_arg == 'value'
+        assert len(r.runner_args.__dict__) == 1


### PR DESCRIPTION
Using a dict() as a default container turned out to be a bad idea, to mix types with the otherwise used `argparse.Namespace`.